### PR TITLE
fix: add system deps to nightly for clang-sys and pyo3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,6 +86,20 @@ jobs:
       - name: Ensure target is installed
         run: rustup target add ${{ matrix.target }}
 
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev python3-dev
+
+      - name: Install system dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install llvm python3
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+
+      - name: Set LIBCLANG_PATH (macOS)
+        if: runner.os == 'macOS'
+        run: echo "LIBCLANG_PATH=$(brew --prefix llvm)/lib" >> $GITHUB_ENV
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary
- Install `libclang-dev` and `python3-dev` on Linux for clang-sys and pyo3-ffi
- Install `llvm` and `python3` on macOS via Homebrew
- Set `LIBCLANG_PATH` env var on macOS so clang-sys can locate libclang

Refs decy#42

## Test plan
- [ ] Trigger nightly workflow manually and verify all 4 targets build

🤖 Generated with [Claude Code](https://claude.com/claude-code)